### PR TITLE
Integrate rulebooks content into main README and remove duplicate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Evaluation framework for [OpenAI Custom GPTs](https://openai.com/index/introduci
 - **📝 `simple-evaluation.md`** - Minimal evaluation method
 - **📋 `PLANNING.md`** - Project roadmap and workflow
 - **📂 `advanced/`** - Complex features for future development
-- **📂 `rulebooks/`** - Reusable rule sets and behavioral protocols that define the core logic for working with and customizing GPTs. Each file is designed to be modular, minimal, and composable — such as `universal-core.md`, which defines foundational behavioral standards and automation protocols for any GPT configuration.
+- **📂 `rulebooks/`** - Reusable rule sets and behavioral protocols that define the core logic for working with and customizing GPTs. Each file is designed to be modular, minimal, and composable — such as [`universal-core.md`](rulebooks/universal-core.md), which defines foundational behavioral standards and automation protocols for any GPT configuration.
 
 ## 🎯 Goal
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Evaluation framework for [OpenAI Custom GPTs](https://openai.com/index/introduci
 - **📝 `simple-evaluation.md`** - Minimal evaluation method
 - **📋 `PLANNING.md`** - Project roadmap and workflow
 - **📂 `advanced/`** - Complex features for future development
-- **📂 `rulebooks/`** - Reusable rule sets and behavioral protocols that define the core logic for working with and customizing GPTs. Each file is designed to be modular, minimal, and composable — such as [`universal-core.md`](rulebooks/universal-core.md), which defines foundational behavioral standards and automation protocols for any GPT configuration.
+- **📂 `rulebooks/`** - Reusable, modular, minimal, and composable behavioral protocols that define the core logic for working with and customizing GPTs.
+  - **📄 [`universal-core.md`](rulebooks/universal-core.md)** - Foundational behavioral standards and automation protocols included in all Custom GPT configurations.
 
 ## 🎯 Goal
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Evaluation framework for [OpenAI Custom GPTs](https://openai.com/index/introduci
 - **📝 `simple-evaluation.md`** - Minimal evaluation method
 - **📋 `PLANNING.md`** - Project roadmap and workflow
 - **📂 `advanced/`** - Complex features for future development
-- **📂 `rulebooks/`** - Reusable rule sets and behavioral protocols that define the core logic for working with and customizing GPTs. Each file is designed to be modular, minimal, and composable.
+- **📂 `rulebooks/`** - Reusable rule sets and behavioral protocols that define the core logic for working with and customizing GPTs. Each file is designed to be modular, minimal, and composable — such as `universal-core.md`, which defines foundational behavioral standards and automation protocols for any GPT configuration.
 
 ## 🎯 Goal
 

--- a/rulebooks/README.md
+++ b/rulebooks/README.md
@@ -1,5 +1,0 @@
-# Rulebooks
-
-This folder contains reusable rule sets and behavioral protocols that define the core logic for working with and customizing GPTs.
-
-Each file is designed to be modular, minimal, and composable — such as `universal-core.md`, which defines foundational behavioral standards and automation protocols for any GPT configuration.


### PR DESCRIPTION
Consolidate the README documentation by integrating the rulebooks content and eliminating the separate rulebooks file to reduce redundancy.

## Summary by Sourcery

Integrate rulebooks content into the main README and remove the now redundant rulebooks README file.

Enhancements:
- Refine rulebooks description in the main README with a reference to the `universal-core.md` example file.

Documentation:
- Merge rulebooks directory documentation into the primary README and delete `rulebooks/README.md`.